### PR TITLE
fix: inconsistent channel sorting on rare.md and count.md

### DIFF
--- a/leaderboards/count.go
+++ b/leaderboards/count.go
@@ -8,6 +8,7 @@ import (
 	"gofish/utils"
 	"os"
 	"path/filepath"
+	"sort"
 	"time"
 )
 
@@ -165,9 +166,27 @@ func writeCount(filePath string, fishCaught map[string]data.FishInfo, titletotal
 
 		_, _ = fmt.Fprintf(file, "| %s %s | %s%s | %s |", ranks, changeEmoji, player, botIndicator, counts)
 		if isGlobal {
+			// Turn the map to a slice
+			ChatCountsSlice := make([]struct {
+				chat  string
+				count int
+			}, 0, 2)
+
+			for k, v := range ChatCounts {
+				ChatCountsSlice = append(ChatCountsSlice, struct {
+					chat  string
+					count int
+				}{k, v})
+			}
+
+			// Sort per-channel counts by channel
+			sort.Slice(ChatCountsSlice, func(i, j int) bool {
+				return ChatCountsSlice[i].chat < ChatCountsSlice[j].chat
+			})
+
 			// Print the count for each chat
-			for chat, count := range ChatCounts {
-				_, _ = fmt.Fprintf(file, " %s(%d) ", chat, count)
+			for _, count := range ChatCountsSlice {
+				_, _ = fmt.Fprintf(file, " %s(%d) ", count.chat, count.count)
 			}
 			_, _ = fmt.Fprint(file, "|")
 		}


### PR DESCRIPTION
the unordered insertion of channel entries on the database would return a non-deterministic order of the per-channel fish count statistics on the global rarest fish leaderboard

i wasn't able to test this fix locally, since i don't have the database or the logs set up on my machine, but it *should* work

tl;dr fixes this:
![yucky](https://github.com/blableblup/gofish/assets/89038897/891d9009-07ea-475a-ac79-bab2bb08f7a3)
